### PR TITLE
Add tool calling (tools/tool_choice) to the protocol server

### DIFF
--- a/MiniCPMO45/modeling_minicpmo_unified.py
+++ b/MiniCPMO45/modeling_minicpmo_unified.py
@@ -3063,6 +3063,7 @@ class MiniCPMO(MiniCPMOPreTrainedModel):
         stream_input=False,
         max_inp_length=8192,
         merge_audio_from_same_content=True,
+        tools=None,
     ):
         """一次性 prefill 所有消息到 KV cache（非流式，复用 chat 的消息解析逻辑）
 
@@ -3111,7 +3112,10 @@ class MiniCPMO(MiniCPMOPreTrainedModel):
         for i, msg in enumerate(copy_msgs):
             role = msg["role"]
             content = msg["content"]
-            assert role in ["system", "user", "assistant"]
+            # "tool" role carries a tool result back into the conversation
+            # (OpenAI-compatible function calling); the chat template renders
+            # it inside <tool_response>.
+            assert role in ["system", "user", "assistant", "tool"]
             if i == 0:
                 assert role in ["user", "system"], "The role of first msg should be user"
             if isinstance(content, str):

--- a/core/processors/pytorch_backend.py
+++ b/core/processors/pytorch_backend.py
@@ -179,6 +179,7 @@ class PyTorchBackend:
         max_slice_nums: Optional[int] = None,
         use_tts_template: bool = False,
         enable_thinking: bool = False,
+        tools=None,
     ) -> str:
         chat_view = self.processor.set_chat_mode()
         return chat_view.prefill(
@@ -188,6 +189,7 @@ class PyTorchBackend:
             max_slice_nums=max_slice_nums,
             use_tts_template=use_tts_template,
             enable_thinking=enable_thinking,
+            tools=tools,
         )
 
     def chat_init_tts(self, ref_audio: Optional[np.ndarray]) -> None:

--- a/core/processors/unified.py
+++ b/core/processors/unified.py
@@ -173,6 +173,7 @@ class ChatView(MiniCPMOProcessorMixin):
         use_tts_template: bool = False,
         enable_thinking: bool = False,
         max_inp_length: int = 8192,
+        tools=None,
     ) -> str:
         """Prefill 所有消息到 KV cache（不含 generation prompt）"""
         self._session_id = session_id
@@ -185,6 +186,7 @@ class ChatView(MiniCPMOProcessorMixin):
             use_tts_template=use_tts_template,
             enable_thinking=enable_thinking,
             max_inp_length=max_inp_length,
+            tools=tools,
         )
         return prompt
     
@@ -572,6 +574,7 @@ class HalfDuplexView(MiniCPMOProcessorMixin):
         max_slice_nums=None,
         use_tts_template: bool = True,
         enable_thinking: bool = False,
+        tools=None,
     ) -> str:
         """非流式预填充：一次性 prefill 所有消息到 KV cache"""
         prompt = self._model.non_streaming_prefill(
@@ -581,6 +584,7 @@ class HalfDuplexView(MiniCPMOProcessorMixin):
             max_slice_nums=max_slice_nums,
             use_tts_template=use_tts_template,
             enable_thinking=enable_thinking,
+            tools=tools,
         )
         return prompt
     

--- a/core/schemas/common.py
+++ b/core/schemas/common.py
@@ -74,7 +74,7 @@ tts = TTSConfig(
 """
 
 from enum import Enum
-from typing import List, Optional, Union, Literal
+from typing import List, Optional, Union, Literal, Dict, Any
 import base64
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -110,6 +110,10 @@ class Role(str, Enum):
     SYSTEM = "system"
     USER = "user"
     ASSISTANT = "assistant"
+    # Tool-calling roles (OpenAI-compatible function calling). "tool" carries a
+    # tool's result back into the conversation; assistant messages may also
+    # carry "tool_calls". Required for the chat template's <tools> block.
+    TOOL = "tool"
 
 
 class TTSMode(str, Enum):
@@ -370,7 +374,15 @@ class Message(BaseModel):
         ..., 
         description="消息内容（字符串或多模态列表）"
     )
-    
+    # OpenAI-compatible function calling. Populated on:
+    #   - assistant messages that the model emitted as tool calls
+    #   - (tool results live in the message whose role is "tool")
+    # Each entry: {"id": str, "type": "function",
+    #              "function": {"name": str, "arguments": str}}
+    # When present, convert_to_model_msgs forwards it so the chat template's
+    # <tools> block can render the assistant tool_call + <tool_response> turns.
+    tool_calls: Optional[List[Dict[str, Any]]] = None
+
     @field_validator("content", mode="before")
     @classmethod
     def normalize_content(cls, v):

--- a/py_backend/chat_util.py
+++ b/py_backend/chat_util.py
@@ -8,8 +8,11 @@ transport-agnostic and reused by the backend protocol server before inference.
 from __future__ import annotations
 
 import base64
+import json
+import re
+import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -28,6 +31,119 @@ class ChatRequestError(ValueError):
     pass
 
 
+# --- Function calling (issue #21) ------------------------------------------
+# The MiniCPM-o 4.5 chat template tells the model to return, inside a fenced
+# tool_call block, a JSON object {"name": <fn>, "arguments": {...}}. The tag
+# strings are built with chr(96) so this source file never contains raw
+# triple-backtick sequences (which some editors/linters mis-render as markdown).
+_BT = chr(96) * 3
+# The chat template opens AND closes the block the same way: a newline, then
+# ```tool_call. So both delimiters are "\n```tool_call".
+_TC_OPEN = "\n" + _BT + "tool_call"
+_TC_CLOSE = "\n" + _BT + "tool_call"
+_TC_RE = re.compile(re.escape(_TC_OPEN) + r"(.*?)" + re.escape(_TC_CLOSE), re.DOTALL)
+# Defensive: some models emit the XML-style tool_call tags referenced in
+# the template's prose instead of the fenced form. Match those too.
+_BT2 = chr(60) + "tool_call" + chr(62)
+_ET2 = chr(60) + "/tool_call" + chr(62)
+_TC_XML_RE = re.compile(re.escape(_BT2) + r"(.*?)" + re.escape(_ET2), re.DOTALL)
+
+
+def _extract_tool_calls(text):
+    """Parse model output into (clean_text, tool_calls).
+
+    Returns a tuple:
+      clean_text  - visible text with any tool_call block removed.
+      tool_calls  - OpenAI-style list the client can execute:
+                    [{"id": "call_<uuid>", "type": "function",
+                      "function": {"name": <fn>, "arguments": <object>}}]
+
+    When no tool_call block is present, returns (text, []). A malformed block is
+    skipped (dropped from tool_calls, still stripped from clean_text) rather than
+    raising, so a single bad block cannot crash the turn.
+    """
+    if not text:
+        return text or "", []
+
+    # Prefer the fenced form (what the template's example output uses); fall
+    # back to the XML-tag form referenced in the template's prose.
+    pat = _TC_RE if _TC_OPEN in text else _TC_XML_RE
+    if _TC_OPEN not in text and _BT2 not in text:
+        return text or "", []
+
+    tool_calls = []
+    last_end = 0
+    clean_parts = []
+    for m in pat.finditer(text):
+        clean_parts.append(text[last_end:m.start()])
+        block = m.group(1).strip()
+        payload = _first_json_object(block)
+        if payload is not None:
+            name = payload.get("name")
+            arguments = payload.get("arguments")
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except (ValueError, TypeError):
+                    pass
+            tool_calls.append({
+                "id": "call_" + uuid.uuid4().hex[:24],
+                "type": "function",
+                "function": {
+                    "name": name if name is not None else "unknown",
+                    "arguments": arguments if arguments is not None else {},
+                },
+            })
+        last_end = m.end()
+    clean_parts.append(text[last_end:])
+
+    clean_text = "".join(clean_parts).strip()
+    clean_text = re.sub(re.escape(_TC_OPEN), "", clean_text).strip()
+    clean_text = re.sub(re.escape(_BT2), "", clean_text).strip()
+    return clean_text, tool_calls
+
+
+def _first_json_object(block):
+    """Return the first balanced {...} object in block as a dict, else None.
+
+    Dependency-free scanner: finds the first "{" that closes at a matching "}"
+    and json.loads that slice. Tracks strings + escapes so braces inside string
+    values do not confuse the depth count.
+    """
+    start = block.find("{")
+    while start != -1:
+        depth = 0
+        in_str = False
+        esc = False
+        end = -1
+        for i in range(start, len(block)):
+            ch = block[i]
+            if in_str:
+                if esc:
+                    esc = False
+                elif ch == "\\":
+                    esc = True
+                elif ch == '"':
+                    in_str = False
+            else:
+                if ch == '"':
+                    in_str = True
+                elif ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        end = i
+                        break
+        if end != -1:
+            try:
+                return json.loads(block[start:end + 1])
+            except (ValueError, TypeError):
+                pass
+        start = block.find("{", start + 1)
+    return None
+
+
 @dataclass
 class WorkerChatRequest:
     messages: list
@@ -40,6 +156,31 @@ class WorkerChatRequest:
     use_tts_template: bool
     omni_mode: bool
     enable_thinking: bool
+    # --- OpenAI-compatible function calling (issue #21 fix) -----------------
+    # Raw `tools` (list of function schemas) and `tool_choice` as sent by the
+    # client. These were previously silently dropped by the protocol, so the
+    # model never saw the tools and could not call them.
+    tools: Optional[list] = None
+    tool_choice: Any = None
+
+    @property
+    def effective_tools(self) -> Optional[list]:
+        """Tools to pass to the chat template.
+
+        Returns `None` (no tool block rendered) when the client explicitly
+        asked for `tool_choice="none"`, or when no tools were provided.
+        `tool_choice="auto"` / a specific function name / omitted -> tools
+        pass through and the model decides per the template's instruction.
+        Note: the MiniCPM-o 4.5 chat template does not itself branch on
+        `tool_choice` (it always lets the model choose), so "auto" and
+        "specific" are honoured the same way: tools are exposed and the model
+        selects. "none" is the only one we enforce by withholding tools.
+        """
+        if not self.tools:
+            return None
+        if isinstance(self.tool_choice, str) and self.tool_choice.lower() == "none":
+            return None
+        return self.tools
 
 
 def parse_worker_chat_request_message(msg: Dict[str, Any]) -> WorkerChatRequest:
@@ -74,6 +215,20 @@ def parse_worker_chat_request_message(msg: Dict[str, Any]) -> WorkerChatRequest:
     if generate_audio and ref_b64:
         tts_ref_audio = np.frombuffer(base64.b64decode(ref_b64), dtype=np.float32)
 
+    # --- Function calling: thread tools / tool_choice through (issue #21) ---
+    # Previously these keys were never read, so OpenAI-style clients sending
+    # `tools` + `tool_choice` had them silently dropped before reaching the model.
+    tools_raw = payload.get("tools")
+    tools: Optional[list] = None
+    if tools_raw is not None:
+        if not isinstance(tools_raw, list):
+            raise ChatRequestError("chat.request tools must be a list")
+        for t in tools_raw:
+            if not isinstance(t, dict):
+                raise ChatRequestError("each tool must be an object")
+        tools = tools_raw
+    tool_choice = payload.get("tool_choice")
+
     return WorkerChatRequest(
         messages=payload.get("messages", []),
         streaming=bool(payload.get("streaming", True)),
@@ -85,6 +240,8 @@ def parse_worker_chat_request_message(msg: Dict[str, Any]) -> WorkerChatRequest:
         use_tts_template=bool(payload.get("use_tts_template", False) or generate_audio),
         omni_mode=bool(payload.get("omni_mode", False)),
         enable_thinking=bool(payload.get("enable_thinking", False)),
+        tools=tools,
+        tool_choice=tool_choice,
     )
 
 
@@ -94,7 +251,12 @@ def parse_raw_messages(raw_messages: List[dict]) -> List[Message]:
     messages: List[Message] = []
     for raw_message in raw_messages:
         role = Role(raw_message["role"])
-        content = raw_message["content"]
+        content = raw_message.get("content", "")
+        tool_calls = raw_message.get("tool_calls") or None
+        # tool_calls only make sense on assistant turns; keep them only there
+        # so the chat template renders them in the right place.
+        if not isinstance(tool_calls, list):
+            tool_calls = None
         if isinstance(content, list):
             content_items: List[ContentItem] = []
             for item in content:
@@ -112,9 +274,14 @@ def parse_raw_messages(raw_messages: List[dict]) -> List[Message]:
                         stack_frames=item.get("stack_frames", 1),
                     ))
             if content_items:
-                messages.append(Message(role=role, content=content_items))
+                messages.append(Message(role=role, content=content_items, tool_calls=tool_calls))
+            else:
+                # A tool-call assistant turn may carry no text content — give it
+                # an empty string so the template's `if content` guard is clean.
+                content_val = "" if tool_calls else content
+                messages.append(Message(role=role, content=content_val, tool_calls=tool_calls))
         else:
-            messages.append(Message(role=role, content=content))
+            messages.append(Message(role=role, content=content, tool_calls=tool_calls))
     return messages
 
 
@@ -130,4 +297,8 @@ def convert_to_model_msgs(schema_messages: List[Message]) -> list:
         if len(content) == 1 and isinstance(content[0], str):
             content = content[0]
         model_msgs.append({"role": message.role.value, "content": content})
+        # Function calling: forward assistant tool_calls so the chat template's
+        # <tools> block can render the <tool_call> turn. Absent for normal turns.
+        if message.tool_calls:
+            model_msgs[-1]["tool_calls"] = message.tool_calls
     return model_msgs

--- a/py_backend/server.py
+++ b/py_backend/server.py
@@ -27,6 +27,7 @@ from py_backend.media import decode_audio_base64, decode_frame_base64_list
 from py_backend.usage import SessionUsage, TokenUsage
 from py_backend.voice import resolve_duplex_voice_refs
 from py_backend.chat_util import (
+    _extract_tool_calls,
     convert_to_model_msgs,
     parse_raw_messages,
     parse_worker_chat_request_message,
@@ -304,6 +305,7 @@ class BackendProtocolSession:
                 max_slice_nums=request.max_slice_nums,
                 use_tts_template=request.use_tts_template,
                 enable_thinking=request.enable_thinking,
+                tools=request.effective_tools,
             )
 
             if request.generate_audio and request.streaming:
@@ -356,12 +358,14 @@ class BackendProtocolSession:
                         )
                     continue
                 if tag == "done":
+                    clean_text, tool_calls = _extract_tool_calls(full_text)
                     await self.send(
                         "response.done",
                         session_id=self.session_id,
                         response_id=response_id,
                         input_id=input_id,
-                        text=full_text,
+                        text=clean_text,
+                        tool_calls=tool_calls or None,
                         reason="turn_end",
                         metrics=self._safe_metrics(),
                     )
@@ -389,6 +393,11 @@ class BackendProtocolSession:
         if isinstance(result, tuple):
             text, waveform = result
 
+        # Function calling: split any <tool_call> from the
+        # visible text and surface structured tool_calls.
+        clean_text, tool_calls = _extract_tool_calls(text or "")
+        text = clean_text
+
         if waveform is not None:
             audio_base64 = base64.b64encode(waveform.astype(np.float32).tobytes()).decode("utf-8")
         else:
@@ -401,6 +410,7 @@ class BackendProtocolSession:
             input_id=input_id,
             text=text or "",
             audio=audio_base64,
+            tool_calls=tool_calls or None,
             reason="turn_end",
             metrics=self._safe_metrics(),
         )

--- a/repro_output.txt
+++ b/repro_output.txt
@@ -1,0 +1,45 @@
+=== [1] Fields the real WorkerChatRequest actually carries ===
+carried fields : ['messages', 'streaming', 'max_new_tokens', 'length_penalty', 'max_slice_nums', 'generate_audio', 'tts_ref_audio', 'use_tts_template', 'omni_mode', 'enable_thinking']
+has 'tools'     : False
+has 'tool_choice': False
+parsed.tools    : None
+parsed.tool_choice: None
+
+=== [2] Client fields SILENTLY DROPPED by the protocol (not passed to the model) ===
+{
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "city"
+          ]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto",
+  "generation": {
+    "max_new_tokens": 256
+  }
+}
+
+=== [3] GenerationConfig fields (sampling layer — no tool fields) ===
+['max_new_tokens', 'min_new_tokens', 'do_sample', 'temperature', 'top_p', 'top_k', 'length_penalty', 'max_inp_length']
+
+=== [4] Message schema fields (message layer — no tool_calls / role=tool) ===
+['role', 'content']
+allowed roles  : ['system', 'user', 'assistant'] | 'tool' role allowed: False
+
+=== [5] Registered HTTP/WS routes (is there an OpenAI-compat chat endpoint?) ===
+['/backend', '/docs', '/docs/oauth2-redirect', '/health', '/openapi.json', '/redoc', '/sessions/{session_id}/close']
+any '/v1/chat/completions' route: False

--- a/repro_toolchoice.py
+++ b/repro_toolchoice.py
@@ -1,0 +1,73 @@
+"""
+Repro for OpenBMB/MiniCPM-o-Demo#21 — "tool_choice=auto doesn't work even in text-only mode".
+
+Runs the repo's REAL chat-request parser (py_backend/chat_util.parse_worker_chat_request_message,
+called on every turn at py_backend/server.py:292) with an OpenAI-style request that carries
+`tools` + `tool_choice=auto`. No model / no GPU needed: the tool fields are handled (or not)
+purely at the wire-protocol layer, before any model call.
+
+Run:  cd <repo> && python3 repro_toolchoice.py
+"""
+import sys, json, dataclasses
+sys.path.insert(0, ".")
+
+from py_backend.chat_util import parse_worker_chat_request_message
+from core.schemas.common import Message, GenerationConfig
+from py_backend.server import app  # noqa: F403  (import to confirm no OpenAI HTTP route)
+
+# ---- What an OpenAI-compatible client actually sends ---------------------
+openai_payload = {
+    "messages": [
+        {"role": "user", "content": "What's the weather in Barcelona today?"},
+    ],
+    "streaming": False,
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ],
+    "tool_choice": "auto",
+    "generation": {"max_new_tokens": 256},
+}
+
+# ---- 1) Feed the REAL parser the client's full payload --------------------
+parsed = parse_worker_chat_request_message({"type": "chat.request", "payload": openai_payload})
+print("=== [1] Fields the real WorkerChatRequest actually carries ===")
+fields = [f.name for f in dataclasses.fields(parsed)]
+print("carried fields :", fields)
+print("has 'tools'     :", "tools" in fields)
+print("has 'tool_choice':", "tool_choice" in fields)
+
+tools_seen = getattr(parsed, "tools", None)
+tool_choice_seen = getattr(parsed, "tool_choice", None)
+print("parsed.tools    :", tools_seen)
+print("parsed.tool_choice:", tool_choice_seen)
+
+dropped = {k: v for k, v in openai_payload.items() if k not in fields and k not in ("messages",)}
+print("\n=== [2] Client fields SILENTLY DROPPED by the protocol (not passed to the model) ===")
+print(json.dumps(dropped, indent=2))
+
+# ---- 3) Prove the schema layers have no tool concept ----------------------
+print("\n=== [3] GenerationConfig fields (sampling layer — no tool fields) ===")
+print([f for f in GenerationConfig.model_fields.keys()])
+
+print("\n=== [4] Message schema fields (message layer — no tool_calls / role=tool) ===")
+print([f for f in Message.model_fields.keys()])
+import core.schemas.common as c
+roles = [r.value for r in c.Role]
+print("allowed roles  :", roles, "| 'tool' role allowed:", "tool" in roles)
+
+# ---- 5) Does the FastAPI app expose any OpenAI /v1/chat/completions route? --
+routes = sorted({getattr(r, "path", "?") for r in app.routes})
+print("\n=== [5] Registered HTTP/WS routes (is there an OpenAI-compat chat endpoint?) ===")
+print(routes)
+print("any '/v1/chat/completions' route:", any("chat/completions" in p for p in routes))

--- a/tests/test_toolchoice.py
+++ b/tests/test_toolchoice.py
@@ -1,0 +1,388 @@
+"""Tool-calling (tools / tool_choice) protocol tests — issue #21.
+
+These tests are MODEL-FREE: they exercise the real protocol/plumbing code
+(parse, schema, message conversion, the ``_push_turn_based`` server path and
+the tool-call output parser) without loading the 18 GB MiniCPM-o weights or a
+GPU. The only optional, network-dependent check renders the prompt through the
+real MiniCPM-o 4.5 tokenizer + chat template and is skipped when that
+tokenizer is not available locally.
+
+Run (no model, no network needed for the core checks)::
+
+    python -m pytest tests/test_toolchoice.py -v
+
+The last test (``test_real_template_renders_tools``) additionally passes when
+a MiniCPM-o tokenizer is reachable, via the ``MINICPM_O_TOK`` env var or a
+local clone. It is ``pytest.skip``-ped otherwise so CI stays green offline.
+
+Coverage
+--------
+1. ``parse_worker_chat_request_message`` carries ``tools`` + ``tool_choice``
+   (previously silently dropped — the root cause of #21).
+2. ``tool_choice="none"`` withholds the tool block (``effective_tools is None``).
+3. ``parse_raw_messages`` + ``convert_to_model_msgs`` carry ``role:"tool"`` and
+   assistant ``tool_calls`` through to the model messages.
+4. The real MiniCPM-o 4.5 tokenizer + chat template render the ``# Tools``
+   block and a ``
+```
+ tool-result round-trip (optional / network).
+5. ``_extract_tool_calls`` parses the fenced ``tool_call`` block (and the XML
+   ``<tool_call>`` form) into OpenAI-style ``tool_calls`` + clean text.
+6. End-to-end: the real ``_push_turn_based`` server method threads
+   ``tools`` into ``chat_prefill``, emits ``tool_calls`` on ``response.done``,
+   feeds a tool result back on turn 2, and honours ``tool_choice="none"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the repo root importable when pytest runs from the tests/ dir.
+_TESTS_DIR = Path(__file__).parent
+_ROOT = _TESTS_DIR.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from py_backend.chat_util import (  # noqa: E402
+    _extract_tool_calls,
+    convert_to_model_msgs,
+    parse_raw_messages,
+    parse_worker_chat_request_message,
+)
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string", "description": "City name"}},
+            "required": ["city"],
+        },
+    },
+}
+
+# The fenced form the chat template instructs the model to emit.
+_BT = chr(96) * 3
+_FENCE_OPEN = "\n" + _BT + "tool_call"
+_FENCE_CLOSE = "\n" + _BT + "tool_call"
+
+
+def _payload(**over):
+    base = {
+        "messages": [{"role": "user", "content": "What's the weather in Barcelona?"}],
+        "streaming": False,
+        "tools": [WEATHER_TOOL],
+        "tool_choice": "auto",
+        "generation": {"max_new_tokens": 256},
+    }
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. Protocol parse
+# ---------------------------------------------------------------------------
+
+def test_parse_carries_tools_and_tool_choice():
+    req = parse_worker_chat_request_message(
+        {"type": "chat.request", "payload": _payload()}
+    )
+    assert req.tools is not None and len(req.tools) == 1
+    assert req.tools[0]["function"]["name"] == "get_weather"
+    assert req.tool_choice == "auto"
+    # effective_tools honours auto (passes tools through).
+    assert req.effective_tools is not None and len(req.effective_tools) == 1
+
+
+def test_parse_tool_choice_none_withholds_tools():
+    req = parse_worker_chat_request_message(
+        {"type": "chat.request", "payload": _payload(tool_choice="none")}
+    )
+    assert req.tools is not None  # raw tools are still captured...
+    assert req.effective_tools is None  # ...but the tool block is withheld.
+
+
+def test_parse_validates_tools_is_list_of_dicts():
+    from py_backend.chat_util import ChatRequestError
+
+    with pytest.raises(ChatRequestError):
+        parse_worker_chat_request_message(
+            {"type": "chat.request", "payload": _payload(tools="not-a-list")}
+        )
+    with pytest.raises(ChatRequestError):
+        parse_worker_chat_request_message(
+            {"type": "chat.request", "payload": _payload(tools=["also-not-a-dict"])}
+        )
+
+
+def test_parse_without_tools_is_backwards_compatible():
+    payload = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "streaming": False,
+        "generation": {},
+    }
+    req = parse_worker_chat_request_message({"type": "chat.request", "payload": payload})
+    assert req.tools is None
+    assert req.tool_choice is None
+    assert req.effective_tools is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Message conversion
+# ---------------------------------------------------------------------------
+
+def test_convert_carries_tool_role_and_tool_calls():
+    raw = [
+        {"role": "user", "content": "Weather in Paris?"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "call_1", "type": "function",
+             "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}
+        ]},
+        {"role": "tool", "content": "{\"temp_c\": 18}"},
+        {"role": "user", "content": "Thanks"},
+    ]
+    model_msgs = convert_to_model_msgs(parse_raw_messages(raw))
+    roles = [m["role"] for m in model_msgs]
+    assert "tool" in roles
+    assistant = next(m for m in model_msgs if m["role"] == "assistant")
+    assert assistant.get("tool_calls"), "assistant tool_calls must survive"
+    assert assistant["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_convert_normal_turn_unchanged():
+    raw = [{"role": "user", "content": "hello"}]
+    model_msgs = convert_to_model_msgs(parse_raw_messages(raw))
+    assert model_msgs == [{"role": "user", "content": "hello"}]
+    assert "tool_calls" not in model_msgs[0]
+
+
+# ---------------------------------------------------------------------------
+# 4. Real template render (optional / network)
+# ---------------------------------------------------------------------------
+
+def _try_load_tokenizer():
+    candidates = []
+    env = os.environ.get("MINICPM_O_TOK")
+    if env:
+        candidates.append(env)
+    candidates += ["/tmp/minicpmo-tok", str(_ROOT / "MiniCPMO45")]
+    from transformers import AutoTokenizer
+    for path in candidates:
+        if not path or not os.path.isdir(path):
+            continue
+        try:
+            # The custom tokenizer class lives in MiniCPMO45/.
+            tok = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
+            return tok
+        except Exception:
+            continue
+    return None
+
+
+def test_real_template_renders_tools():
+    tok = _try_load_tokenizer()
+    if tok is None:
+        pytest.skip(
+            "MiniCPM-o tokenizer not available locally; set MINICPM_O_TOK to run "
+            "the real-template render check."
+        )
+    prompt = tok.apply_chat_template(
+        [{"role": "user", "content": "Weather in Barcelona?"}],
+        tools=[WEATHER_TOOL], tokenize=False, add_generation_prompt=True,
+    )
+    assert "# Tools" in prompt
+    assert "get_weather" in prompt
+    # The template tells the model to emit a tool_call block.
+    assert "tool_call" in prompt
+
+    # Round-trip: feed a tool result back and confirm it renders.
+    roundtrip = tok.apply_chat_template(
+        [
+            {"role": "user", "content": "Weather in Paris?"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}
+            ]},
+            {"role": "tool", "content": "{\"temp_c\": 18}"},
+            {"role": "user", "content": "Thanks"},
+        ],
+        tools=[WEATHER_TOOL], tokenize=False, add_generation_prompt=True,
+    )
+    assert "<tool_response>" in roundtrip
+    assert '{"temp_c": 18}' in roundtrip
+    assert "get_weather" in roundtrip
+
+
+# ---------------------------------------------------------------------------
+# 5. Output parser
+# ---------------------------------------------------------------------------
+
+def test_extract_fenced_tool_call():
+    model_out = (
+        "Here you go." + _FENCE_OPEN
+        + '{"name": "get_weather", "arguments": {"city": "Barcelona"}}'
+        + _FENCE_CLOSE
+    )
+    clean, calls = _extract_tool_calls(model_out)
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["type"] == "function"
+    assert c["id"].startswith("call_")
+    assert c["function"]["name"] == "get_weather"
+    assert c["function"]["arguments"] == {"city": "Barcelona"}
+    # Visible text does not leak the raw fence.
+    assert "tool_call" not in clean
+    assert clean.strip() == "Here you go."
+
+
+def test_extract_xml_tool_call():
+    open_tag = chr(60) + "tool_call" + chr(62)
+    close_tag = chr(60) + "/tool_call" + chr(62)
+    model_out = "checking" + "\n" + open_tag + \
+        '{"name": "get_weather", "arguments": {"city": "Madrid"}}' + "\n" + close_tag
+    clean, calls = _extract_tool_calls(model_out)
+    assert len(calls) == 1
+    assert calls[0]["function"]["name"] == "get_weather"
+    assert calls[0]["function"]["arguments"] == {"city": "Madrid"}
+
+
+def test_extract_arguments_as_string():
+    # Double-encoded arguments: the model emitted the arguments object as a
+    # JSON string inside the tool_call block. json.dumps keeps the escaping
+    # correct.
+    inner = json.dumps({"city": "Lisbon"})  # '{"city": "Lisbon"}'
+    payload = json.dumps({"name": "get_weather", "arguments": inner})
+    model_out = _FENCE_OPEN + payload + _FENCE_CLOSE
+    _, calls = _extract_tool_calls(model_out)
+    assert len(calls) == 1
+    assert calls[0]["function"]["name"] == "get_weather"
+    # A JSON-string argument is parsed into an object.
+    assert calls[0]["function"]["arguments"] == {"city": "Lisbon"}
+
+
+def test_extract_no_tool_call_is_passthrough():
+    text = "Just a normal answer."
+    clean, calls = _extract_tool_calls(text)
+    assert calls == []
+    assert clean == text
+
+
+def test_extract_malformed_block_does_not_crash():
+    model_out = "hi" + _FENCE_OPEN + "not json at all" + _FENCE_CLOSE
+    clean, calls = _extract_tool_calls(model_out)
+    assert calls == []  # malformed block skipped, not raised
+    assert "not json" not in clean
+
+
+# ---------------------------------------------------------------------------
+# 6. End-to-end through the real _push_turn_based server path
+# ---------------------------------------------------------------------------
+
+class _FakeWS:
+    def __init__(self):
+        self.events = []
+
+    async def send_json(self, data):
+        self.events.append(data)
+
+
+class _StubBackend:
+    """Stands in ONLY for model inference; everything else is real code."""
+
+    def __init__(self, first_output):
+        self.prefill_kwargs = None
+        self._first = first_output
+        self._n = 0
+
+    def metrics(self):
+        return {"backend": "stub"}
+
+    def chat_prefill(self, **kw):
+        self.prefill_kwargs = kw
+        return "prompt"
+
+    def chat_non_streaming_generate(self, **kw):
+        self._n += 1
+        if self._n == 1:
+            return self._first
+        return "It is 18C in Barcelona."
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_e2e_tools_roundtrip_and_none():
+    from py_backend.server import BackendProtocolSession
+
+    model_out = (
+        "Let me check.\n" + _FENCE_OPEN
+        + '{"name": "get_weather", "arguments": {"city": "Barcelona"}}'
+        + _FENCE_CLOSE
+    )
+
+    async def scenario():
+        ws = _FakeWS()
+        backend = _StubBackend(model_out)
+        session = BackendProtocolSession(
+            session_id="sess_e2e", mode="turn_based",
+            backend=backend, ws=ws, state=None,
+        )
+
+        # TURN 1: ask about the weather with tools attached.
+        await session._push_turn_based(_payload(response_id="resp1", input_id="in1"))
+
+        # tools reached the prefill (the fix's core claim).
+        assert backend.prefill_kwargs is not None
+        assert backend.prefill_kwargs.get("tools")
+        assert backend.prefill_kwargs["tools"][0]["function"]["name"] == "get_weather"
+
+        done1 = next(e for e in ws.events if e.get("type") == "response.done")
+        assert done1.get("tool_calls") and len(done1["tool_calls"]) == 1
+        c = done1["tool_calls"][0]
+        assert c["function"]["name"] == "get_weather"
+        assert c["function"]["arguments"] == {"city": "Barcelona"}
+        assert c["id"].startswith("call_")
+        assert "tool_call" not in done1.get("text", "")
+
+        # TURN 2: feed the tool result back.
+        ws.events.clear()
+        turn2_msgs = [
+            {"role": "user", "content": "What's the weather in Barcelona?"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_abc", "type": "function",
+                 "function": {"name": "get_weather", "arguments": '{"city": "Barcelona"}'}}
+            ]},
+            {"role": "tool", "content": '{"temp_c": 18, "condition": "sunny"}'},
+            {"role": "user", "content": "Thanks, got it?"},
+        ]
+        await session._push_turn_based(
+            _payload(messages=turn2_msgs, response_id="resp2", input_id="in2")
+        )
+        msgs2 = backend.prefill_kwargs.get("msgs", [])
+        assert any(m.get("role") == "tool" for m in msgs2)
+        assert any(m.get("tool_calls") for m in msgs2)
+        done2 = next(e for e in ws.events if e.get("type") == "response.done")
+        assert "tool_calls" not in done2  # final answer: no tool calls
+        assert done2.get("text") == "It is 18C in Barcelona."
+
+        # tool_choice="none" withholds the tool block.
+        ws.events.clear()
+        await session._push_turn_based(
+            _payload(response_id="resp3", input_id="in3", tool_choice="none")
+        )
+        assert backend.prefill_kwargs.get("tools") is None
+
+    _run(scenario())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

OpenAI-style clients that send `tools` + `tool_choice` with a `chat.request` had both fields **silently dropped** by the protocol before reaching the model, so function calling never worked — even in text-only mode (#21).

Reproduction (no model needed): the repo's own parser `parse_worker_chat_request_message` builds a `WorkerChatRequest` whose fields are `messages, streaming, max_new_tokens, length_penalty, max_slice_nums, generate_audio, tts_ref_audio, use_tts_template, omni_mode, enable_thinking` — no `tools`, no `tool_choice`. Feeding it a standard OpenAI-style payload with `tools` + `tool_choice="auto"` drops the fields with no error or warning. The `Message` schema also has no `role: "tool"` or `tool_calls`, so the tool loop could not be fed back even if the first call worked.

## Fix

Thread `tools` / `tool_choice` through the full request→template chain and parse the model's tool-call output into a structured `tool_calls` response:

- **`core/schemas/common.py`** — `Role.TOOL`; `Message.tool_calls` (additive, `None` by default).
- **`py_backend/chat_util.py`**
  - `WorkerChatRequest` carries `tools` + `tool_choice`; new `effective_tools` property honours `tool_choice="none"` by withholding the tool block.
  - `parse_worker_chat_request_message` now reads and validates those keys.
  - `parse_raw_messages` / `convert_to_model_msgs` carry `role: "tool"` and assistant `tool_calls` into the model messages.
  - New `_extract_tool_calls()` parses the model's tool-call output (the fenced `tool_call` block the template instructs, plus the XML-tag form referenced in the template prose) into OpenAI-style `tool_calls` + clean visible text. Malformed blocks are skipped, never raised.
- **`py_backend/server.py`** — `_push_turn_based` passes `request.effective_tools` into `backend.chat_prefill`; both `response.done` emits (stream + non-stream) carry `tool_calls` when present. `send()` drops `None` fields, so the wire format is byte-identical for normal turns.
- **`core/processors/{unified,pytorch_backend}.py`, `MiniCPMO45/modeling_minicpmo_unified.py`** — `non_streaming_prefill(tools=...)` → `apply_chat_template(tools=...)`; the role assertion accepts `"tool"`.

## Evidence

- **Repro artifacts** (in this PR): `repro_toolchoice.py` runs the repo's real parser on an OpenAI-style payload with `tools` + `tool_choice="auto"`; `repro_output.txt` shows the fields dropped before the fix.
- **`tests/test_toolchoice.py`** — 13 checks, no model / no GPU needed:
  - protocol parse carries `tools`/`tool_choice`; `tool_choice="none"` withholds tools; input validation; backwards compatibility without tools
  - `role:"tool"` + assistant `tool_calls` survive message conversion
  - **the real MiniCPM-o 4.5 tokenizer + chat template render the `# Tools` block and a full `<tool_response>` round-trip** (auto-skipped if the tokenizer isn't cached locally; set `MINICPM_O_TOK` to run it — passed locally)
  - `_extract_tool_calls` handles the fenced form, the XML form, double-encoded arguments, passthrough, and malformed blocks
  - end-to-end drive of the **real `_push_turn_based`** across two turns (tools in → structured `tool_calls` out → tool result fed back → final answer clean; `tool_choice="none"` variant) via a stub inference backend

Run: `python -m pytest tests/test_toolchoice.py -v` → **13 passed**.

## Honest scope

- Verified end-to-end at the protocol + real-template boundary: the model now receives the tools in a correctly rendered prompt, and the model's tool-call output is parsed into structured `tool_calls`. The one step not exercised here is actual model inference (requires the 18 GB weights); the real-template render test is the decisive evidence that the prompt the model will see contains the tool definitions.
- The standalone `chat()` and `streaming_prefill()` paths (used by the raw demo UI, not the protocol server) are not wired to accept `tools` in this change — a natural follow-up.
- `tool_choice` semantics: the template itself does not branch on `tool_choice` (the model always decides from the exposed tools), so `auto`/specific are honoured by exposing the tools; `none` is enforced by withholding them.

Closes #21.
